### PR TITLE
Rewrite doctrine wrapper to use stdin/stdout instead of writing files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
     - OCAML_VERSION=4.04
     - OCAML_VERSION=4.03
     - OCAML_VERSION=4.02
-    - OCAML_VERSION=4.01
-    - OCAML_VERSION=4.00
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   global:
     - PACKAGE=JS_Parser
   matrix:
+    - OCAML_VERSION=4.05
     - OCAML_VERSION=4.04
     - OCAML_VERSION=4.03
     - OCAML_VERSION=4.02

--- a/lib/node_modules/get-stdin/index.js
+++ b/lib/node_modules/get-stdin/index.js
@@ -1,0 +1,52 @@
+'use strict';
+var stdin = process.stdin;
+
+module.exports = function () {
+	var ret = '';
+
+	return new Promise(function (resolve) {
+		if (stdin.isTTY) {
+			resolve(ret);
+			return;
+		}
+
+		stdin.setEncoding('utf8');
+
+		stdin.on('readable', function () {
+			var chunk;
+
+			while ((chunk = stdin.read())) {
+				ret += chunk;
+			}
+		});
+
+		stdin.on('end', function () {
+			resolve(ret);
+		});
+	});
+};
+
+module.exports.buffer = function () {
+	var ret = [];
+	var len = 0;
+
+	return new Promise(function (resolve) {
+		if (stdin.isTTY) {
+			resolve(new Buffer(''));
+			return;
+		}
+
+		stdin.on('readable', function () {
+			var chunk;
+
+			while ((chunk = stdin.read())) {
+				ret.push(chunk);
+				len += chunk.length;
+			}
+		});
+
+		stdin.on('end', function () {
+			resolve(Buffer.concat(ret, len));
+		});
+	});
+};

--- a/lib/node_modules/get-stdin/license
+++ b/lib/node_modules/get-stdin/license
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/lib/node_modules/get-stdin/package.json
+++ b/lib/node_modules/get-stdin/package.json
@@ -1,0 +1,74 @@
+{
+  "_from": "get-stdin",
+  "_id": "get-stdin@5.0.1",
+  "_inBundle": false,
+  "_integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+  "_location": "/get-stdin",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "tag",
+    "registry": true,
+    "raw": "get-stdin",
+    "name": "get-stdin",
+    "escapedName": "get-stdin",
+    "rawSpec": "",
+    "saveSpec": null,
+    "fetchSpec": "latest"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+  "_shasum": "122e161591e21ff4c52530305693f20e6393a398",
+  "_spec": "get-stdin",
+  "_where": "/home/thomas/JS_Parser/lib",
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/get-stdin/issues"
+  },
+  "bundleDependencies": false,
+  "deprecated": false,
+  "description": "Get stdin as a string or buffer",
+  "devDependencies": {
+    "ava": "*",
+    "buffer-equals": "^1.0.3",
+    "xo": "*"
+  },
+  "engines": {
+    "node": ">=0.12.0"
+  },
+  "files": [
+    "index.js"
+  ],
+  "homepage": "https://github.com/sindresorhus/get-stdin#readme",
+  "keywords": [
+    "std",
+    "stdin",
+    "stdio",
+    "concat",
+    "buffer",
+    "stream",
+    "process",
+    "read"
+  ],
+  "license": "MIT",
+  "name": "get-stdin",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sindresorhus/get-stdin.git"
+  },
+  "scripts": {
+    "test": "xo && ava test.js && echo unicorns | ava test-real.js"
+  },
+  "version": "5.0.1",
+  "xo": {
+    "ignores": [
+      "test.js"
+    ]
+  }
+}

--- a/lib/node_modules/get-stdin/readme.md
+++ b/lib/node_modules/get-stdin/readme.md
@@ -1,0 +1,55 @@
+# get-stdin [![Build Status](https://travis-ci.org/sindresorhus/get-stdin.svg?branch=master)](https://travis-ci.org/sindresorhus/get-stdin)
+
+> Get [stdin](https://nodejs.org/api/process.html#process_process_stdin) as a string or buffer
+
+
+## Install
+
+```
+$ npm install --save get-stdin
+```
+
+
+## Usage
+
+```js
+// example.js
+const getStdin = require('get-stdin');
+
+getStdin().then(str => {
+	console.log(str);
+	//=> 'unicorns'
+});
+```
+
+```
+$ echo unicorns | node example.js
+unicorns
+```
+
+
+## API
+
+Both methods returns a promise that is resolved when the `end` event fires on the `stdin` stream, indicating that there is no more data to be read.
+
+### getStdin()
+
+Get `stdin` as a string.
+
+In a TTY context, a promise that resolves to an empty string is returned.
+
+### getStdin.buffer()
+
+Get `stdin` as a buffer.
+
+In a TTY context, a promise that resolves to an empty buffer is returned.
+
+
+## Related
+
+- [get-stream](https://github.com/sindresorhus/get-stream) - Get a stream as a string or buffer
+
+
+## License
+
+MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/lib/npm-shrinkwrap.json
+++ b/lib/npm-shrinkwrap.json
@@ -1,26 +1,33 @@
 {
   "name": "js_parser",
   "version": "0.2.0",
+  "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "doctrine": {
-      "version": "1.5.0",
-      "from": "doctrine@*",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz"
+      "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "requires": {
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+      }
     },
     "esprima": {
-      "version": "1.2.5",
-      "from": "resource-reasoning/esprima#jscert",
-      "resolved": "git://github.com/resource-reasoning/esprima.git#7796274e6d2d9cade83ab1b9e5954cfadbd574e6"
+      "version": "git://github.com/resource-reasoning/esprima.git#7796274e6d2d9cade83ab1b9e5954cfadbd574e6",
+      "integrity": "sha1-Y2RQnc/4rbdJSwybbOGYR+4dpMI="
     },
     "esutils": {
-      "version": "2.0.2",
-      "from": "esutils@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+      "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "get-stdin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
     },
     "isarray": {
-      "version": "1.0.0",
-      "from": "isarray@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+      "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     }
   }
 }

--- a/lib/package.json
+++ b/lib/package.json
@@ -12,6 +12,7 @@
   "repository": "github:resource-reasoning/JS_Parser",
   "dependencies": {
     "doctrine": "^1.5.0",
-    "esprima": "github:resource-reasoning/esprima#jscert"
+    "esprima": "github:resource-reasoning/esprima#jscert",
+    "get-stdin": "^5.0.1"
   }
 }

--- a/lib/run_doctrine.js
+++ b/lib/run_doctrine.js
@@ -1,29 +1,20 @@
 var doctrine = require('doctrine');
-var fs = require('fs');
+var getStdin = require('get-stdin');
 
-var comment = process.argv[2];
-var output = process.argv[3];
-
-fs.readFile(comment, 'utf8', function (err,data) {
-	if (err) {
-		process.stdout.write("Horrible error.\n")
-	}
-
-	comment = data;
-
-	var out = JSON.stringify(doctrine.parse(comment,
+getStdin().then(str => {
+	var out = JSON.stringify(doctrine.parse(str,
 		{ unwrap : true,
-		  tags : ["toprequires", 
-		          "topensures", 
-		          "topensureserr", 
-		          "pre", 
-		          "post", 
-		          "posterr", 
-		          "id", 
-		          "pred", 
+		  tags : ["toprequires",
+		          "topensures",
+		          "topensureserr",
+		          "pre",
+		          "post",
+		          "posterr",
+		          "id",
+		          "pred",
 		          "onlyspec",
 		          "invariant",
 		          "tactic",
 		          "lemma"] }), null);
-	fs.writeFile(output, out, [], null);
+	process.stdout.write(out);
 });

--- a/opam
+++ b/opam
@@ -18,6 +18,8 @@ build: [[make]]
 build-test: [[make "test_all"]]
 build-doc: [[make "doc"]]
 # install target uses JS_Parser.install automatically
+
+available: [ocaml-version >= "4.04.0"]
 depends: [
   "ocamlfind"
   "batteries"


### PR DESCRIPTION
Hopefully this will fix #7.

@PetarMax could you test this change to make sure it doesn't break annotation reading? The test suite doesn't seem to adequately cover this. (I attempted to break it by passing empty input (`stdin`) to the `Yojson.Safe.from_channel` function, but the tests still passed).